### PR TITLE
Model aided pose estimator implementation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,30 @@
+BSD 3-Clause License
+
+Copyright (c) 2016-2017, Deutsches Forschungszentrum für Künstliche Intelligenz GmbH.
+Copyright (c) 2016-2017, University of Bremen
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its contributors
+  may be used to endorse or promote products derived from this software
+  without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,18 @@
 uwv_kalman_filters
 =============
-Collection of filters for the underwater vehicle context
 
+VelocityUKF
+---
+The focus of the VelocityUKF is to provide a model-aided linear and angular velocity estimate.  Due to the model-aiding the velocities can be provided in a high frequency.
+
+PoseUKF
+---
+The PoseUKF is a model aided inertial localization solution for autonomous underwater vehicles. As minimal input the filter relays on rotation rates and accelerations from an IMU and velocities from a DVL.  Given force and torque measurements an AUV motion model aids the velocity estimate during DVL drop outs.  ADCP measurements further aid the estimation in cases of DVL bottom-lock loss. Given gyroscopes capable of sensing the rotation of the earth (e.g. a fiber optic gyro) the filter is able to estimate it's true heading.
 
 
 License
 -------
-dummy-license
+BSD 3-Clause License
 
 Installation
 ------------
@@ -33,6 +39,7 @@ processes and simplify reuse of this project. Following these rules ensures that
 the Rock CMake macros automatically handle the project's build process and
 install setup properly.
 
+```
 STRUCTURE
 -- src/ 
 	Contains all header (*.h/*.hpp) and source files
@@ -53,3 +60,4 @@ STRUCTURE
 	easily embedded include the external software directly here
 -- doc/
 	should contain the existing doxygen file: doxygen.conf
+```

--- a/manifest.xml
+++ b/manifest.xml
@@ -7,6 +7,7 @@
   <url>http://</url>
   <logo>http://</logo>
   <depend package="base/cmake" />
+  <depend package="base/logging" />
   <depend package="slam/mtk" />
   <depend package="slam/pose_estimation" />
   <depend package="control/uwv_dynamic_model" />

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 rock_library(uwv_kalman_filters
-    SOURCES VelocityUKF.cpp
-    HEADERS VelocityUKF.hpp
-    DEPS_PKGCONFIG pose_estimation uwv_dynamic_model eigen3 base-types base-lib
+    SOURCES VelocityUKF.cpp PoseUKF.cpp
+    HEADERS VelocityUKF.hpp PoseUKF.hpp PoseState.hpp PoseUKFConfig.hpp
+    DEPS_PKGCONFIG pose_estimation uwv_dynamic_model eigen3 base-types base-lib base-logging
     DEPS_CMAKE LAPACK)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,9 @@
 rock_library(uwv_kalman_filters
-    SOURCES VelocityUKF.cpp PoseUKF.cpp
-    HEADERS VelocityUKF.hpp PoseUKF.hpp PoseState.hpp PoseUKFConfig.hpp
+    SOURCES VelocityUKF.cpp
+            PoseUKF.cpp
+    HEADERS VelocityUKF.hpp
+            PoseUKF.hpp
+            PoseState.hpp
+            PoseUKFConfig.hpp
     DEPS_PKGCONFIG pose_estimation uwv_dynamic_model eigen3 base-types base-lib base-logging
     DEPS_CMAKE LAPACK)

--- a/src/PoseState.hpp
+++ b/src/PoseState.hpp
@@ -18,6 +18,8 @@ typedef ukfom::mtkwrap<RotationType::vect_type> VelocityType;
 typedef ukfom::mtkwrap<RotationType::vect_type> AccelerationType;
 typedef ukfom::mtkwrap<RotationType::vect_type> BiasType;
 typedef ukfom::mtkwrap< MTK::vect<1> > GravityType;
+typedef ukfom::mtkwrap< MTK::matrix<2,3> > LinDampingType;
+typedef ukfom::mtkwrap< MTK::matrix<2,3> > QuadDampingType;
 
 MTK_BUILD_MANIFOLD(PoseState,
    ((TranslationType, position)) // position of IMU in navigation frame
@@ -27,6 +29,8 @@ MTK_BUILD_MANIFOLD(PoseState,
    ((BiasType, bias_gyro))
    ((BiasType, bias_acc))
    ((GravityType, gravity))
+   ((LinDampingType, lin_damping)) // [x, xy, xψ; yx, y, yψ] components of the damping matrix in row-major order. ψ is the rotation around the z-axis.
+   ((QuadDampingType, quad_damping)) // [x, xy, xψ; yx, y, yψ] components of the damping matrix in row-major order. ψ is the rotation around the z-axis.
 )
 
 }

--- a/src/PoseState.hpp
+++ b/src/PoseState.hpp
@@ -18,6 +18,7 @@ typedef ukfom::mtkwrap<RotationType::vect_type> VelocityType;
 typedef ukfom::mtkwrap<RotationType::vect_type> AccelerationType;
 typedef ukfom::mtkwrap<RotationType::vect_type> BiasType;
 typedef ukfom::mtkwrap< MTK::vect<1> > GravityType;
+typedef ukfom::mtkwrap< MTK::matrix<2,3> > InertiaType;
 typedef ukfom::mtkwrap< MTK::matrix<2,3> > LinDampingType;
 typedef ukfom::mtkwrap< MTK::matrix<2,3> > QuadDampingType;
 typedef ukfom::mtkwrap< MTK::vect<2> > WaterVelocityType;
@@ -28,11 +29,12 @@ MTK_BUILD_MANIFOLD(PoseState,
    ((RotationType, orientation)) // orientation of IMU in navigation frame
    ((VelocityType, velocity)) // velocity of IMU in navigation frame
    ((AccelerationType, acceleration)) // acceleration of IMU in navigation frame
-   ((BiasType, bias_gyro))
-   ((BiasType, bias_acc))
-   ((GravityType, gravity))
-   ((LinDampingType, lin_damping)) // [x, xy, xψ; yx, y, yψ] components of the damping matrix in row-major order. ψ is the rotation around the z-axis.
-   ((QuadDampingType, quad_damping)) // [x, xy, xψ; yx, y, yψ] components of the damping matrix in row-major order. ψ is the rotation around the z-axis.
+   ((BiasType, bias_gyro)) // gyroscope bias states
+   ((BiasType, bias_acc)) // acceleration bias states
+   ((GravityType, gravity)) // local gravity, to refine the WGS-84 ellipsoid earth gravity model
+   ((InertiaType, inertia)) // [x, xy, xψ; yx, y, yψ] components of the inertia matrix in row-major order. ψ is the rotation around the z-axis.
+   ((LinDampingType, lin_damping)) // [x, xy, xψ; yx, y, yψ] components of the linear damping matrix in row-major order. ψ is the rotation around the z-axis.
+   ((QuadDampingType, quad_damping)) // [x, xy, xψ; yx, y, yψ] components of the quadratic damping matrix in row-major order. ψ is the rotation around the z-axis.
    ((WaterVelocityType, water_velocity)) // Water current velocity surrounding the vehicle, in the North/East directions
    ((WaterVelocityType, water_velocity_below)) // Water current velocity below the vehicle, in the North/East directions
    ((AdcpBiasType, bias_adcp)) // ADCP bias states

--- a/src/PoseState.hpp
+++ b/src/PoseState.hpp
@@ -20,9 +20,9 @@ typedef ukfom::mtkwrap<RotationType::vect_type> BiasType;
 typedef ukfom::mtkwrap< MTK::vect<1> > GravityType;
 
 MTK_BUILD_MANIFOLD(PoseState,
-   ((TranslationType, position)) // position of IMU in navigation/target frame
-   ((RotationType, orientation)) // orientation of IMU in navigation/target frame
-   ((VelocityType, velocity)) // velocity of IMU in navigation/target frame
+   ((TranslationType, position)) // position of IMU in navigation frame
+   ((RotationType, orientation)) // orientation of IMU in navigation frame
+   ((VelocityType, velocity)) // velocity of IMU in navigation frame
    ((AccelerationType, acceleration)) // acceleration in IMU frame
    ((BiasType, bias_gyro))
    ((BiasType, bias_acc))

--- a/src/PoseState.hpp
+++ b/src/PoseState.hpp
@@ -20,6 +20,8 @@ typedef ukfom::mtkwrap<RotationType::vect_type> BiasType;
 typedef ukfom::mtkwrap< MTK::vect<1> > GravityType;
 typedef ukfom::mtkwrap< MTK::matrix<2,3> > LinDampingType;
 typedef ukfom::mtkwrap< MTK::matrix<2,3> > QuadDampingType;
+typedef ukfom::mtkwrap< MTK::vect<2> > WaterVelocityType;
+typedef ukfom::mtkwrap< MTK::vect<2> > AdcpBiasType;
 
 MTK_BUILD_MANIFOLD(PoseState,
    ((TranslationType, position)) // position of IMU in navigation frame
@@ -31,6 +33,9 @@ MTK_BUILD_MANIFOLD(PoseState,
    ((GravityType, gravity))
    ((LinDampingType, lin_damping)) // [x, xy, xψ; yx, y, yψ] components of the damping matrix in row-major order. ψ is the rotation around the z-axis.
    ((QuadDampingType, quad_damping)) // [x, xy, xψ; yx, y, yψ] components of the damping matrix in row-major order. ψ is the rotation around the z-axis.
+   ((WaterVelocityType, water_velocity)) // Water current velocity surrounding the vehicle, in the North/East directions
+   ((WaterVelocityType, water_velocity_below)) // Water current velocity below the vehicle, in the North/East directions
+   ((AdcpBiasType, bias_adcp)) // ADCP bias states
 )
 
 }

--- a/src/PoseState.hpp
+++ b/src/PoseState.hpp
@@ -1,0 +1,34 @@
+#ifndef _UWV_KALMAN_FILTERS_POSE_STATE_HPP_
+#define _UWV_KALMAN_FILTERS_POSE_STATE_HPP_
+
+/** MTK library **/
+#include <mtk/src/SubManifold.hpp>
+#include <mtk/types/SOn.hpp>
+#include <mtk/types/vect.hpp>
+#include <mtk/build_manifold.hpp>
+#include <mtk/startIdx.hpp>
+#include <ukfom/mtkwrap.hpp>
+
+namespace uwv_kalman_filters
+{
+
+typedef ukfom::mtkwrap< MTK::SO3<double> > RotationType;
+typedef ukfom::mtkwrap<RotationType::vect_type> TranslationType;
+typedef ukfom::mtkwrap<RotationType::vect_type> VelocityType;
+typedef ukfom::mtkwrap<RotationType::vect_type> AccelerationType;
+typedef ukfom::mtkwrap<RotationType::vect_type> BiasType;
+typedef ukfom::mtkwrap< MTK::vect<1> > GravityType;
+
+MTK_BUILD_MANIFOLD(PoseState,
+   ((TranslationType, position)) // position of IMU in navigation/target frame
+   ((RotationType, orientation)) // orientation of IMU in navigation/target frame
+   ((VelocityType, velocity)) // velocity of IMU in navigation/target frame
+   ((AccelerationType, acceleration)) // acceleration in IMU frame
+   ((BiasType, bias_gyro))
+   ((BiasType, bias_acc))
+   ((GravityType, gravity))
+)
+
+}
+
+#endif

--- a/src/PoseState.hpp
+++ b/src/PoseState.hpp
@@ -25,7 +25,7 @@ MTK_BUILD_MANIFOLD(PoseState,
    ((TranslationType, position)) // position of IMU in navigation frame
    ((RotationType, orientation)) // orientation of IMU in navigation frame
    ((VelocityType, velocity)) // velocity of IMU in navigation frame
-   ((AccelerationType, acceleration)) // acceleration in IMU frame
+   ((AccelerationType, acceleration)) // acceleration of IMU in navigation frame
    ((BiasType, bias_gyro))
    ((BiasType, bias_acc))
    ((GravityType, gravity))

--- a/src/PoseUKF.cpp
+++ b/src/PoseUKF.cpp
@@ -1,0 +1,173 @@
+#include "PoseUKF.hpp"
+#include <base/Float.hpp>
+#include <base-logging/Logging.hpp>
+#include <uwv_dynamic_model/DynamicModel.hpp>
+#include <pose_estimation/GravityModel.hpp>
+
+using namespace uwv_kalman_filters;
+
+// process model
+template <typename FilterState>
+FilterState
+processModel(const FilterState &state, const Eigen::Vector3d& rotation_rate, const Eigen::Vector3d& earth_rotation,
+             double gyro_bias_tau, double acc_bias_tau, double delta_time)
+{
+    FilterState new_state(state);
+
+    // apply velocity
+    new_state.position.boxplus(state.velocity, delta_time);
+
+    // apply angular velocity
+    Eigen::Vector3d angular_velocity = state.orientation * (rotation_rate - state.bias_gyro) - earth_rotation;
+    new_state.orientation.boxplus(angular_velocity, delta_time);
+
+    // apply acceleration
+    Eigen::Vector3d acceleration = state.orientation * state.acceleration;
+    new_state.velocity.boxplus(acceleration, delta_time);
+
+    Eigen::Vector3d gyro_bias_delta = (-1.0/gyro_bias_tau) * state.bias_gyro;
+    new_state.bias_gyro.boxplus(gyro_bias_delta, delta_time);
+
+    Eigen::Vector3d acc_bias_delta = (-1.0/acc_bias_tau) * state.bias_acc;
+    new_state.bias_acc.boxplus(acc_bias_delta, delta_time);
+
+    return new_state;
+}
+
+// measurement models
+template <typename FilterState>
+Eigen::Matrix<TranslationType::scalar, 2, 1>
+measurementXYPosition(const FilterState &state)
+{
+    return state.position.block(0,0,2,1);
+}
+
+template <typename FilterState>
+Eigen::Matrix<TranslationType::scalar, 1, 1>
+measurementZPosition(const FilterState &state)
+{
+    return state.position.block(2,0,1,1);
+}
+
+template <typename FilterState>
+VelocityType
+measurementVelocity(const FilterState &state)
+{
+    // return expected velocities in the IMU frame
+    return VelocityType(state.orientation.inverse() * state.velocity);
+}
+
+template <typename FilterState>
+AccelerationType
+measurementAcceleration(const FilterState &state)
+{
+    // returns expected accelerations in the IMU frame
+    return AccelerationType(state.acceleration + state.bias_acc + state.orientation.inverse() * Eigen::Vector3d(0., 0., state.gravity(0)));
+}
+
+template <typename FilterState>
+Eigen::Matrix<TranslationType::scalar, 3, 1>
+measurementEfforts(const FilterState &state, boost::shared_ptr<uwv_dynamic_model::DynamicModel> dynamic_model,
+                    const Eigen::Vector3d& imu_in_body, const Eigen::Vector3d& rotation_rate,
+                   const Eigen::Vector3d& earth_rotation)
+{
+    RotationType::base orientation_inv = state.orientation.inverse();
+
+    // for the rotation rate IMU and body frame a the same, since they are not rotated to each other
+    Eigen::Vector3d rotation_rate_body = rotation_rate - state.bias_gyro - orientation_inv * earth_rotation;
+    // assume center of rotation to be the body frame
+    Eigen::Vector3d velocity_body = orientation_inv * state.velocity - rotation_rate_body.cross(imu_in_body);
+    base::Vector6d velocity_6d;
+    velocity_6d << velocity_body, rotation_rate_body;
+
+    // assume center of rotation to be the body frame
+    Eigen::Vector3d acceleration_body = Eigen::Vector3d(state.acceleration) - rotation_rate_body.cross(rotation_rate_body.cross(imu_in_body));
+    base::Vector6d acceleration_6d;
+    // assume the angular acceleration to be zero
+    acceleration_6d << acceleration_body, base::Vector3d::Zero();
+
+    base::Vector6d efforts = dynamic_model->calcEfforts(acceleration_6d, velocity_6d, state.orientation);
+
+    // returns the expected linear body efforts given the current state
+    return efforts.block(0,0,3,1);
+}
+
+PoseUKF::PoseUKF(const State& initial_state, const Covariance& state_cov,
+                const LocationConfiguration& location, const uwv_dynamic_model::UWVParameters& model_parameters,
+                const Eigen::Vector3d& imu_in_body, double gyro_bias_tau, double acc_bias_tau) :
+                    imu_in_body(imu_in_body), gyro_bias_tau(gyro_bias_tau), acc_bias_tau(acc_bias_tau)
+{
+    initializeFilter(initial_state, state_cov);
+
+    rotation_rate = RotationRate::Mu::Zero();
+
+    earth_rotation = Eigen::Vector3d(pose_estimation::EARTHW * cos(location.latitude), 0., pose_estimation::EARTHW * sin(location.latitude));
+
+    dynamic_model.reset(new uwv_dynamic_model::DynamicModel());
+    dynamic_model->setUWVParameters(model_parameters);
+}
+
+
+void PoseUKF::predictionStepImpl(double delta_t)
+{
+    Eigen::Matrix3d rot = ukf->mu().orientation.matrix();
+    Covariance process_noise = process_noise_cov;
+    // uncertainty matrix calculations
+    process_noise.block(3,3,3,3) = rot * process_noise_cov.block(3,3,3,3) * rot.transpose();
+    process_noise.block(6,6,3,3) = rot * process_noise_cov.block(6,6,3,3) * rot.transpose();
+    process_noise = pow(delta_t, 2.) * process_noise;
+
+    ukf->predict(boost::bind(processModel<WState>, _1, rotation_rate, earth_rotation, gyro_bias_tau, acc_bias_tau, delta_t),
+                 MTK_UKF::cov(process_noise));
+}
+
+void PoseUKF::integrateMeasurement(const Velocity& velocity)
+{
+    checkMeasurment(velocity.mu, velocity.cov);
+    ukf->update(velocity.mu, boost::bind(measurementVelocity<State>, _1),
+                boost::bind(ukfom::id< Velocity::Cov >, velocity.cov),
+                ukfom::accept_any_mahalanobis_distance<State::scalar>);
+}
+
+void PoseUKF::integrateMeasurement(const Acceleration& acceleration)
+{
+    checkMeasurment(acceleration.mu, acceleration.cov);
+    ukf->update(acceleration.mu, boost::bind(measurementAcceleration<State>, _1),
+                boost::bind(ukfom::id< Acceleration::Cov >, acceleration.cov),
+                ukfom::accept_any_mahalanobis_distance<State::scalar>);
+}
+
+void PoseUKF::integrateMeasurement(const RotationRate& rotation_rate)
+{
+    checkMeasurment(rotation_rate.mu, rotation_rate.cov);
+    this->rotation_rate = rotation_rate.mu;
+}
+
+void PoseUKF::integrateMeasurement(const Z_Position& z_position)
+{
+    checkMeasurment(z_position.mu, z_position.cov);
+    ukf->update(z_position.mu, boost::bind(measurementZPosition<State>, _1),
+                boost::bind(ukfom::id< Z_Position::Cov >, z_position.cov),
+                ukfom::accept_any_mahalanobis_distance<State::scalar>);
+}
+
+void PoseUKF::integrateMeasurement(const XY_Position& xy_position)
+{
+    checkMeasurment(xy_position.mu, xy_position.cov);
+    ukf->update(xy_position.mu, boost::bind(measurementXYPosition<State>, _1),
+                boost::bind(ukfom::id< XY_Position::Cov >, xy_position.cov),
+                ukfom::accept_any_mahalanobis_distance<State::scalar>);
+}
+
+void PoseUKF::integrateMeasurement(const BodyEffortsMeasurement& body_efforts)
+{
+    checkMeasurment(body_efforts.mu, body_efforts.cov);
+    ukf->update(body_efforts.mu, boost::bind(measurementEfforts<State>, _1, dynamic_model, imu_in_body, rotation_rate, earth_rotation),
+                boost::bind(ukfom::id< BodyEffortsMeasurement::Cov >, body_efforts.cov),
+                ukfom::accept_any_mahalanobis_distance<State::scalar>);
+}
+
+PoseUKF::RotationRate::Mu PoseUKF::getRotationRate()
+{
+    return rotation_rate - ukf->mu().bias_gyro - ukf->mu().orientation.inverse() * earth_rotation;
+}

--- a/src/PoseUKF.cpp
+++ b/src/PoseUKF.cpp
@@ -125,7 +125,7 @@ measurementWaterCurrents(const FilterState &state, double cell_weighting)
 }
 
 template <typename FilterState>
-Eigen::Matrix<TranslationType::scalar, 3, 1>
+Eigen::Matrix<TranslationType::scalar, 6, 1>
 measurementEfforts(const FilterState &state, boost::shared_ptr<uwv_dynamic_model::DynamicModel> dynamic_model,
                    const Eigen::Vector3d& imu_in_body, const Eigen::Vector3d& rotation_rate_body)
 {
@@ -159,13 +159,13 @@ measurementEfforts(const FilterState &state, boost::shared_ptr<uwv_dynamic_model
 
     base::Vector6d efforts = dynamic_model->calcEfforts(acceleration_6d, velocity_6d, state.orientation);
 
-    // returns the expected linear body efforts given the current state
-    return efforts.head<3>();
+    // returns the expected forces and torques given the current state
+    return efforts;
 }
 
 /* This measurement model allows to constrain the velocity based on the motion model in the absence of effort measurements */
 template <typename FilterState>
-Eigen::Matrix<TranslationType::scalar, 3, 1>
+Eigen::Matrix<TranslationType::scalar, 6, 1>
 constrainVelocity(const FilterState &state, boost::shared_ptr<uwv_dynamic_model::DynamicModel> dynamic_model,
                    const Eigen::Vector3d& imu_in_body, const Eigen::Vector3d& rotation_rate_body,
                    const Eigen::Vector3d& water_velocity, const Eigen::Quaterniond& orientation,
@@ -182,8 +182,8 @@ constrainVelocity(const FilterState &state, boost::shared_ptr<uwv_dynamic_model:
 
     base::Vector6d efforts = dynamic_model->calcEfforts(acceleration_6d, velocity_6d, orientation);
 
-    // returns the expected linear body efforts given the current state
-    return efforts.head<3>();
+    // returns the expected forces and torques given the current state
+    return efforts;
 }
 
 //functions for innovation gate test, using mahalanobis distance

--- a/src/PoseUKF.cpp
+++ b/src/PoseUKF.cpp
@@ -236,7 +236,7 @@ void PoseUKF::integrateMeasurement(const Velocity& velocity)
     checkMeasurment(velocity.mu, velocity.cov);
     ukf->update(velocity.mu, boost::bind(measurementVelocity<State>, _1),
         boost::bind(ukfom::id< Velocity::Cov >, velocity.cov),
-        d2p99<State::scalar>);
+        ukfom::accept_any_mahalanobis_distance<State::scalar>);
 }
 
 void PoseUKF::integrateMeasurement(const Acceleration& acceleration)

--- a/src/PoseUKF.cpp
+++ b/src/PoseUKF.cpp
@@ -2,7 +2,7 @@
 #include <base/Float.hpp>
 #include <base-logging/Logging.hpp>
 #include <uwv_dynamic_model/DynamicModel.hpp>
-#include <pose_estimation/GravityModel.hpp>
+#include <pose_estimation/GravitationalModel.hpp>
 
 using namespace uwv_kalman_filters;
 

--- a/src/PoseUKF.hpp
+++ b/src/PoseUKF.hpp
@@ -29,6 +29,7 @@ public:
         Eigen::Vector3d imu_in_body;
         double gyro_bias_tau;
         double acc_bias_tau;
+        double inertia_tau;
         double lin_damping_tau;
         double quad_damping_tau;
         double heading_converged_std;
@@ -90,6 +91,7 @@ protected:
     boost::shared_ptr<pose_estimation::GeographicProjection> projection;
     RotationRate::Mu rotation_rate;
     PoseUKFParameter filter_parameter;
+    InertiaType::vectorized_type inertia_offset;
     LinDampingType::vectorized_type lin_damping_offset;
     QuadDampingType::vectorized_type quad_damping_offset;
 };

--- a/src/PoseUKF.hpp
+++ b/src/PoseUKF.hpp
@@ -75,7 +75,7 @@ public:
     void integrateMeasurement(const Velocity& velocity);
 
     /* Linear efforts in the body frame */
-    void integrateMeasurement(const BodyEffortsMeasurement& body_efforts);
+    void integrateMeasurement(const BodyEffortsMeasurement& body_efforts, bool only_affect_velocity = false);
    
     /* Water Velocities from ADCP expressed in the IMU frame */
     void integrateMeasurement(const WaterVelocityMeasurement& adcp_measurements, double cell_weighting);

--- a/src/PoseUKF.hpp
+++ b/src/PoseUKF.hpp
@@ -24,6 +24,7 @@ namespace uwv_kalman_filters
 class PoseUKF : public pose_estimation::UnscentedKalmanFilter<PoseState>
 {
 public:
+    MEASUREMENT(GeographicPosition, 2)
     MEASUREMENT(XY_Position, 2)
     MEASUREMENT(Z_Position, 1)
     MEASUREMENT(RotationRate, 3)
@@ -36,6 +37,11 @@ public:
             const LocationConfiguration& location, const uwv_dynamic_model::UWVParameters& model_parameters,
             const Eigen::Vector3d& imu_in_body, double gyro_bias_tau, double acc_bias_tau);
     virtual ~PoseUKF() {}
+
+    /* Latitude and Longitude in WGS 84 in radian.
+     * Uncertainty expressed in m on earth surface */
+    void integrateMeasurement(const GeographicPosition& geo_position,
+                              const Eigen::Vector3d& gps_in_body = Eigen::Vector3d::Zero());
 
     /* 2D Position expressed in the navigation frame */
     void integrateMeasurement(const XY_Position& xy_position);

--- a/src/PoseUKF.hpp
+++ b/src/PoseUKF.hpp
@@ -21,6 +21,20 @@ namespace pose_estimation
 namespace uwv_kalman_filters
 {
 
+/**
+ * This implements a full model aided inertial localization solution for autonomous underwater vehicles.
+ *
+ * As minimal input the filter relays on rotation rates and accelerations from an IMU and velocities from a DVL.
+ * Given force and torque measurements an AUV motion model aids the velocity estimate during DVL drop outs.
+ * ADCP measurements further aid the estimation in cases of DVL bottom-lock loss.
+ * Given gyroscopes capable of sensing the rotation of the earth (e.g. a fiber optic gyro)
+ * this filter is able to estimate it's true heading.
+ *
+ * NOTE: In this filter the IMU frame is, in order to keep a certain algorithmic simplicity,
+ * not considered to be rotated with respect to the body frame.
+ * Rotation rates and acceleration, as well as the corresponding configuration parameters
+ * therefore would need to be rotated to the body frame before integrating them in this filter.
+ */
 class PoseUKF : public pose_estimation::UnscentedKalmanFilter<PoseState>
 {
 public:
@@ -73,7 +87,7 @@ public:
     /* Velocities expressed in the IMU frame */
     void integrateMeasurement(const Velocity& velocity);
 
-    /* Linear efforts in the body frame */
+    /* Forces and torques in the body frame */
     void integrateMeasurement(const BodyEffortsMeasurement& body_efforts, bool only_affect_velocity = false);
    
     /* Water Velocities from ADCP expressed in the IMU frame */

--- a/src/PoseUKF.hpp
+++ b/src/PoseUKF.hpp
@@ -13,6 +13,11 @@ namespace uwv_dynamic_model
     class DynamicModel;
 }
 
+namespace pose_estimation
+{
+    class GeographicProjection;
+}
+
 namespace uwv_kalman_filters
 {
 
@@ -41,7 +46,7 @@ public:
     /* Rotation rates of IMU expressed in the IMU frame */
     void integrateMeasurement(const RotationRate& rotation_rate);
 
-    /* Accelerations of IMU exxpressed in the IMU frame */
+    /* Accelerations of IMU expressed in the IMU frame */
     void integrateMeasurement(const Acceleration& acceleration);
 
     /* Velocities expressed in the IMU frame */
@@ -58,8 +63,8 @@ protected:
 
 
     boost::shared_ptr<uwv_dynamic_model::DynamicModel> dynamic_model;
+    boost::shared_ptr<pose_estimation::GeographicProjection> projection;
     RotationRate::Mu rotation_rate;
-    Eigen::Vector3d earth_rotation;
     Eigen::Vector3d imu_in_body;
     double gyro_bias_tau;
     double acc_bias_tau;

--- a/src/PoseUKF.hpp
+++ b/src/PoseUKF.hpp
@@ -1,0 +1,70 @@
+#ifndef _UWV_KALMAN_FILTERS_POSE_UKF_HPP_
+#define _UWV_KALMAN_FILTERS_POSE_UKF_HPP_
+
+#include <base/Time.hpp>
+#include <pose_estimation/UnscentedKalmanFilter.hpp>
+#include <pose_estimation/Measurement.hpp>
+#include <uwv_dynamic_model/DataTypes.hpp>
+#include "PoseState.hpp"
+#include "PoseUKFConfig.hpp"
+
+namespace uwv_dynamic_model
+{
+    class DynamicModel;
+}
+
+namespace uwv_kalman_filters
+{
+
+class PoseUKF : public pose_estimation::UnscentedKalmanFilter<PoseState>
+{
+public:
+    MEASUREMENT(XY_Position, 2)
+    MEASUREMENT(Z_Position, 1)
+    MEASUREMENT(RotationRate, 3)
+    MEASUREMENT(Acceleration, 3)
+    MEASUREMENT(Velocity, 3)
+    MEASUREMENT(BodyEffortsMeasurement, 3)
+
+public:
+    PoseUKF(const State& initial_state, const Covariance& state_cov,
+            const LocationConfiguration& location, const uwv_dynamic_model::UWVParameters& model_parameters,
+            const Eigen::Vector3d& imu_in_body, double gyro_bias_tau, double acc_bias_tau);
+    virtual ~PoseUKF() {}
+
+    /* 2D Position expressed in the navigation frame */
+    void integrateMeasurement(const XY_Position& xy_position);
+
+    /* Altitude of IMU expressed in the navigation frame */
+    void integrateMeasurement(const Z_Position& z_position);
+
+    /* Rotation rates of IMU expressed in the IMU frame */
+    void integrateMeasurement(const RotationRate& rotation_rate);
+
+    /* Accelerations of IMU exxpressed in the IMU frame */
+    void integrateMeasurement(const Acceleration& acceleration);
+
+    /* Velocities expressed in the IMU frame */
+    void integrateMeasurement(const Velocity& velocity);
+
+    /* Linear efforts in the body frame */
+    void integrateMeasurement(const BodyEffortsMeasurement& body_efforts);
+
+    /* Returns rotation rate in IMU frame */
+    RotationRate::Mu getRotationRate();
+
+protected:
+    void predictionStepImpl(double delta_t);
+
+
+    boost::shared_ptr<uwv_dynamic_model::DynamicModel> dynamic_model;
+    RotationRate::Mu rotation_rate;
+    Eigen::Vector3d earth_rotation;
+    Eigen::Vector3d imu_in_body;
+    double gyro_bias_tau;
+    double acc_bias_tau;
+};
+
+}
+
+#endif

--- a/src/PoseUKF.hpp
+++ b/src/PoseUKF.hpp
@@ -31,6 +31,7 @@ public:
         double acc_bias_tau;
         double lin_damping_tau;
         double quad_damping_tau;
+        double heading_converged_std;
     };
 
     MEASUREMENT(GeographicPosition, 2)

--- a/src/PoseUKF.hpp
+++ b/src/PoseUKF.hpp
@@ -32,11 +32,10 @@ public:
         double inertia_tau;
         double lin_damping_tau;
         double quad_damping_tau;
-        double heading_converged_std;
         double water_velocity_tau; // time constant for water currents
         double water_velocity_limits; //long term 1 sigma bounds for currents
         double water_velocity_scale; // spatial scale for water current change in m/s / m
-        double adcp_bias_tau; 
+        double adcp_bias_tau;
     };
 
     MEASUREMENT(GeographicPosition, 2)

--- a/src/PoseUKF.hpp
+++ b/src/PoseUKF.hpp
@@ -24,6 +24,15 @@ namespace uwv_kalman_filters
 class PoseUKF : public pose_estimation::UnscentedKalmanFilter<PoseState>
 {
 public:
+    struct PoseUKFParameter
+    {
+        Eigen::Vector3d imu_in_body;
+        double gyro_bias_tau;
+        double acc_bias_tau;
+        double lin_damping_tau;
+        double quad_damping_tau;
+    };
+
     MEASUREMENT(GeographicPosition, 2)
     MEASUREMENT(XY_Position, 2)
     MEASUREMENT(Z_Position, 1)
@@ -35,7 +44,7 @@ public:
 public:
     PoseUKF(const State& initial_state, const Covariance& state_cov,
             const LocationConfiguration& location, const uwv_dynamic_model::UWVParameters& model_parameters,
-            const Eigen::Vector3d& imu_in_body, double gyro_bias_tau, double acc_bias_tau);
+            const PoseUKFParameter& filter_parameter);
     virtual ~PoseUKF() {}
 
     /* Latitude and Longitude in WGS 84 in radian.
@@ -71,9 +80,9 @@ protected:
     boost::shared_ptr<uwv_dynamic_model::DynamicModel> dynamic_model;
     boost::shared_ptr<pose_estimation::GeographicProjection> projection;
     RotationRate::Mu rotation_rate;
-    Eigen::Vector3d imu_in_body;
-    double gyro_bias_tau;
-    double acc_bias_tau;
+    PoseUKFParameter filter_parameter;
+    LinDampingType::vectorized_type lin_damping_offset;
+    QuadDampingType::vectorized_type quad_damping_offset;
 };
 
 }

--- a/src/PoseUKF.hpp
+++ b/src/PoseUKF.hpp
@@ -45,7 +45,7 @@ public:
     MEASUREMENT(RotationRate, 3)
     MEASUREMENT(Acceleration, 3)
     MEASUREMENT(Velocity, 3)
-    MEASUREMENT(BodyEffortsMeasurement, 3)
+    MEASUREMENT(BodyEffortsMeasurement, 6)
     MEASUREMENT(WaterVelocityMeasurement, 2)
 
 public:

--- a/src/PoseUKF.hpp
+++ b/src/PoseUKF.hpp
@@ -32,6 +32,10 @@ public:
         double lin_damping_tau;
         double quad_damping_tau;
         double heading_converged_std;
+        double water_velocity_tau; // time constant for water currents
+        double water_velocity_limits; //long term 1 sigma bounds for currents
+        double water_velocity_scale; // spatial scale for water current change in m/s / m
+        double adcp_bias_tau; 
     };
 
     MEASUREMENT(GeographicPosition, 2)
@@ -41,6 +45,7 @@ public:
     MEASUREMENT(Acceleration, 3)
     MEASUREMENT(Velocity, 3)
     MEASUREMENT(BodyEffortsMeasurement, 3)
+    MEASUREMENT(WaterVelocityMeasurement, 2)
 
 public:
     PoseUKF(const State& initial_state, const Covariance& state_cov,
@@ -70,6 +75,9 @@ public:
 
     /* Linear efforts in the body frame */
     void integrateMeasurement(const BodyEffortsMeasurement& body_efforts);
+   
+    /* Water Velocities from ADCP expressed in the IMU frame */
+    void integrateMeasurement(const WaterVelocityMeasurement& adcp_measurements, double cell_weighting);
 
     /* Returns rotation rate in IMU frame */
     RotationRate::Mu getRotationRate();

--- a/src/PoseUKFConfig.hpp
+++ b/src/PoseUKFConfig.hpp
@@ -1,0 +1,50 @@
+#ifndef _UWV_KALMAN_FILTERS_POSE_UKF_CONFIG_HPP
+#define _UWV_KALMAN_FILTERS_POSE_UKF_CONFIG_HPP
+
+#include <base/Eigen.hpp>
+
+namespace uwv_kalman_filters
+{
+
+struct InertialNoiseParameters
+{
+    /*  Random walk ((m/s^s)/sqrt(Hz) for accelerometers or (rad/s)/sqrt(Hz) for gyros) */
+    base::Vector3d randomwalk;
+
+    /*  Bias offset in static regimen (initial bias value) */
+    base::Vector3d bias_offset;
+
+    /* Bias instability (m/s^2 for accelerometers or rad/s for gyros) */
+    base::Vector3d bias_instability;
+
+    /* Tau value to limit the bias gain in seconds */
+    double bias_tau;
+};
+
+struct LocationConfiguration
+{
+    /* Latitude in radians */
+    double latitude;
+
+    /* Longitude in radians */
+    double longitude;
+
+    /* Altitude in meters */
+    double altitude;
+};
+
+struct PoseUKFConfig
+{
+    /* Inerial noise parameters for acceleration */
+    InertialNoiseParameters acceleration;
+
+    /** Inerial noise parameters for acceleration */
+    InertialNoiseParameters rotation_rate;
+
+    /* Latitude and Longitude of operational area */
+    LocationConfiguration location;
+};
+
+}
+
+#endif

--- a/src/PoseUKFConfig.hpp
+++ b/src/PoseUKFConfig.hpp
@@ -53,17 +53,26 @@ struct DynamicModelNoiseParameters
     /* Standard deviation of linear body effort measurements (N/sqrt(Hz)) */
     base::Vector3d body_efforts_std;
 
+    /* Moment of inertia instability (kg*m^2)
+     * The instability is mapped to the x, yx, xy, y, xψ, yψ components of
+     * the inertia matrix. ψ is the rotation around the z-axis.
+     */
+    base::Vector6d inertia_instability;
+
     /* Liniar damping parameter instability (kg/s)
      * The instability is mapped to the x, yx, xy, y, xψ, yψ components of
-     * the damping matrix. ψ is the rotation around the z-axis.
+     * the linear damping matrix. ψ is the rotation around the z-axis.
      */
     base::Vector6d lin_damping_instability;
 
     /* Quadratic damping parameter instability (kg/m)
      * The instability is mapped to the x, yx, xy, y, xψ, yψ components of
-     * the damping matrix. ψ is the rotation around the z-axis.
+     * the quadratic damping matrix. ψ is the rotation around the z-axis.
      */
     base::Vector6d quad_damping_instability;
+
+    /* Tau value to limit the bias gain in seconds */
+    double inertia_tau;
 
     /* Tau value to limit the bias gain in seconds */
     double lin_damping_tau;

--- a/src/PoseUKFConfig.hpp
+++ b/src/PoseUKFConfig.hpp
@@ -53,8 +53,9 @@ struct InertialNoiseParameters
 
 struct DynamicModelNoiseParameters
 {
-    /* Standard deviation of linear body effort measurements (N/sqrt(Hz)) */
-    base::Vector3d body_efforts_std;
+    /* Standard deviation of body effort measurements.
+     * Forces in (N/sqrt(Hz)) and torques in (Nm/sqrt(Hz)) */
+    base::Vector6d body_efforts_std;
 
     /* Moment of inertia instability (kg*m^2)
      * The instability is mapped to the x, yx, xy, y, xψ, yψ components of
@@ -116,12 +117,12 @@ struct PoseUKFConfig
     /** Max change of acceleration in m/s^3 */
     base::Vector3d max_jerk;
 
-    /** Max effort in N
+    /** Max effort in N and Nm
      * This is used to define the uncertainty of
      * unknown effort measurements.
      * E.g. if the AUV is on the surface.
      */
-    base::Vector3d max_effort;
+    base::Vector6d max_effort;
 
     /* Minimum depth of the AUV to apply the dynamic model  */
     double dynamic_model_min_depth;

--- a/src/PoseUKFConfig.hpp
+++ b/src/PoseUKFConfig.hpp
@@ -81,6 +81,9 @@ struct PoseUKFConfig
     /** Noise parameter for the dynamic motion model */
     DynamicModelNoiseParameters model_noise_parameters;
 
+    /* Water velocity parameters */
+    WaterVelocityParameters water_velocity;
+
     /* Latitude and Longitude of operational area */
     LocationConfiguration location;
 

--- a/src/PoseUKFConfig.hpp
+++ b/src/PoseUKFConfig.hpp
@@ -14,6 +14,9 @@ struct WaterVelocityParameters
     /* limits of the water current change from temporal change */
     double limits;
 
+    /* Standard deviation of the water velocity measurements ((m/s)/sqrt(Hz)) */
+    base::Vector2d measurement_std;
+
     /* rate change of currents based on spatial change */
     double scale;
 

--- a/src/PoseUKFConfig.hpp
+++ b/src/PoseUKFConfig.hpp
@@ -8,14 +8,28 @@ namespace uwv_kalman_filters
 
 struct WaterVelocityParameters
 {
-    double tau; // time scale for water current change
+    /* time scale for water current change */
+    double tau;
 
-    double limits; // limits of the water current change from temporal change
+    /* limits of the water current change from temporal change */
+    double limits;
 
-    double scale; // rate change of currents based on spatial change
+    /* rate change of currents based on spatial change */
+    double scale;
 
-    double adcp_bias_tau; 
+    /* Water current cell size in meter */
+    double cell_size;
 
+    /* Water current first cell blank in meter */
+    double first_cell_blank;
+
+    /* Minimum correltation of ADCP measurements */
+    double minimum_correlation;
+
+    /* Time scale for change of ADCP bias in seconds */
+    double adcp_bias_tau;
+
+    /* ADCP bias standard deviation */
     double adcp_bias_limits;
 };
 

--- a/src/PoseUKFConfig.hpp
+++ b/src/PoseUKFConfig.hpp
@@ -15,7 +15,7 @@ struct WaterVelocityParameters
     double limits;
 
     /* Standard deviation of the water velocity measurements ((m/s)/sqrt(Hz)) */
-    base::Vector2d measurement_std;
+    base::Vector3d measurement_std;
 
     /* rate change of currents based on spatial change */
     double scale;

--- a/src/PoseUKFConfig.hpp
+++ b/src/PoseUKFConfig.hpp
@@ -70,6 +70,9 @@ struct PoseUKFConfig
 
     /* Latitude and Longitude of operational area */
     LocationConfiguration location;
+
+    /** Max change of acceleration in m/s^3 */
+    base::Vector3d max_jerk;
 };
 
 }

--- a/src/PoseUKFConfig.hpp
+++ b/src/PoseUKFConfig.hpp
@@ -106,11 +106,6 @@ struct PoseUKFConfig
 
     /* Minimum depth of the AUV to apply the dynamic model  */
     double dynamic_model_min_depth;
-
-    /* Lower border of heading uncertainty after it is considered to be stable.
-     * This allows to use the state orientation in the velocity integration.
-     */
-    double heading_converged_std;
 };
 
 }

--- a/src/PoseUKFConfig.hpp
+++ b/src/PoseUKFConfig.hpp
@@ -21,6 +21,30 @@ struct InertialNoiseParameters
     double bias_tau;
 };
 
+struct DynamicModelNoiseParameters
+{
+    /* Standard deviation of linear body effort measurements (N/sqrt(Hz)) */
+    base::Vector3d body_efforts_std;
+
+    /* Liniar damping parameter instability (kg/s)
+     * The instability is mapped to the x, yx, xy, y, xψ, yψ components of
+     * the damping matrix. ψ is the rotation around the z-axis.
+     */
+    base::Vector6d lin_damping_instability;
+
+    /* Quadratic damping parameter instability (kg/m)
+     * The instability is mapped to the x, yx, xy, y, xψ, yψ components of
+     * the damping matrix. ψ is the rotation around the z-axis.
+     */
+    base::Vector6d quad_damping_instability;
+
+    /* Tau value to limit the bias gain in seconds */
+    double lin_damping_tau;
+
+    /* Tau value to limit the bias gain in seconds */
+    double quad_damping_tau;
+};
+
 struct LocationConfiguration
 {
     /* Latitude in radians */
@@ -40,6 +64,9 @@ struct PoseUKFConfig
 
     /** Inerial noise parameters for acceleration */
     InertialNoiseParameters rotation_rate;
+
+    /** Noise parameter for the dynamic motion model */
+    DynamicModelNoiseParameters model_noise_parameters;
 
     /* Latitude and Longitude of operational area */
     LocationConfiguration location;

--- a/src/PoseUKFConfig.hpp
+++ b/src/PoseUKFConfig.hpp
@@ -87,6 +87,9 @@ struct PoseUKFConfig
      * E.g. if the AUV is on the surface.
      */
     base::Vector3d max_effort;
+
+    /* Minimum depth of the AUV to apply the dynamic model  */
+    double dynamic_model_min_depth;
 };
 
 }

--- a/src/PoseUKFConfig.hpp
+++ b/src/PoseUKFConfig.hpp
@@ -90,6 +90,11 @@ struct PoseUKFConfig
 
     /* Minimum depth of the AUV to apply the dynamic model  */
     double dynamic_model_min_depth;
+
+    /* Lower border of heading uncertainty after it is considered to be stable.
+     * This allows to use the state orientation in the velocity integration.
+     */
+    double heading_converged_std;
 };
 
 }

--- a/src/PoseUKFConfig.hpp
+++ b/src/PoseUKFConfig.hpp
@@ -116,13 +116,6 @@ struct PoseUKFConfig
     /** Max change of acceleration in m/s^3 */
     base::Vector3d max_jerk;
 
-    /** Max velocity in m/s
-     * This is used to define the uncertainty of
-     * unknown velocity measurements.
-     * E.g. if the DVL has no bottom lock.
-     */
-    base::Vector3d max_velocity;
-
     /** Max effort in N
      * This is used to define the uncertainty of
      * unknown effort measurements.

--- a/src/PoseUKFConfig.hpp
+++ b/src/PoseUKFConfig.hpp
@@ -73,6 +73,20 @@ struct PoseUKFConfig
 
     /** Max change of acceleration in m/s^3 */
     base::Vector3d max_jerk;
+
+    /** Max velocity in m/s
+     * This is used to define the uncertainty of
+     * unknown velocity measurements.
+     * E.g. if the DVL has no bottom lock.
+     */
+    base::Vector3d max_velocity;
+
+    /** Max effort in N
+     * This is used to define the uncertainty of
+     * unknown effort measurements.
+     * E.g. if the AUV is on the surface.
+     */
+    base::Vector3d max_effort;
 };
 
 }

--- a/src/PoseUKFConfig.hpp
+++ b/src/PoseUKFConfig.hpp
@@ -6,6 +6,19 @@
 namespace uwv_kalman_filters
 {
 
+struct WaterVelocityParameters
+{
+    double tau; // time scale for water current change
+
+    double limits; // limits of the water current change from temporal change
+
+    double scale; // rate change of currents based on spatial change
+
+    double adcp_bias_tau; 
+
+    double adcp_bias_limits;
+};
+
 struct InertialNoiseParameters
 {
     /*  Random walk ((m/s^s)/sqrt(Hz) for accelerometers or (rad/s)/sqrt(Hz) for gyros) */

--- a/src/VelocityUKF.hpp
+++ b/src/VelocityUKF.hpp
@@ -26,6 +26,10 @@ MTK_BUILD_MANIFOLD(VelocityState,
    ((ZPosType, z_position))
 )
 
+/**
+ * The focus of this filter is to provide a model-aided linear and angular velocity estimate.
+ * Due to the model-aiding the velocities can be provided in a high frequency.
+ */
 class VelocityUKF : public pose_estimation::UnscentedKalmanFilter<VelocityState>
 {
 public:
@@ -38,11 +42,19 @@ public:
     VelocityUKF(const State& initial_state, const Covariance& state_cov);
     virtual ~VelocityUKF() {}
 
+    /** Set AUV motion model parameters */
     bool setupMotionModel(const uwv_dynamic_model::UWVParameters& parameters);
 
+    /** Velocity of the AUV */
     void integrateMeasurement(const DVLMeasurement& measurement);
+
+    /** Rotation rates of the AUV */
     void integrateMeasurement(const GyroMeasurement& measurement);
+
+    /** Forces and torques in the body frame */
     void integrateMeasurement(const BodyEffortsMeasurement& measurement);
+
+    /** Altitude to the AUV */
     void integrateMeasurement(const PressureMeasurement& measurement);
 
 protected:


### PR DESCRIPTION
The PoseUKF is a model aided inertial localization solution for autonomous underwater vehicles. As minimal input the filter relays on rotation rates and accelerations from an IMU and velocities from a DVL.  Given force and torque measurements an AUV motion model aids the velocity estimate during DVL drop outs.  ADCP measurements further aid the estimation in cases of DVL bottom-lock loss. Given gyroscopes capable of sensing the rotation of the earth (e.g. a fiber optic gyro) the filter is able to estimate it's true heading.